### PR TITLE
Edit .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*


### PR DESCRIPTION
ChatSpaceは画像の投稿を行なう機能が備わっていますが、投稿された画像自体はソースコードには関係のないものです。そこで、あらかじめ画像が保
管されるpublic/uploadsディレクトリを.gitignoreに追加